### PR TITLE
Fix issue #9

### DIFF
--- a/Zarr.m
+++ b/Zarr.m
@@ -55,9 +55,14 @@ classdef Zarr < handle
                 insert(py.sys.path,int32(0),modpath);
             end
             
-            % Load the Python module
-            mod = py.importlib.import_module('ZarrPy');
-            py.importlib.reload(mod);
+            % Check if the ZarrPy module is loaded already. If not, load
+            % it.
+            sys = py.importlib.import_module('sys');
+            LoadedModules = dictionary(sys.modules);
+            if ~LoadedModules.isKey("ZarrPy")
+                mod = py.importlib.import_module('ZarrPy');
+                py.importlib.reload(mod);
+            end
 
             obj.Path = path;
             isRemote = matlab.io.internal.vfs.validators.hasIriPrefix(obj.Path);
@@ -118,8 +123,11 @@ classdef Zarr < handle
             
             % The Python function returns the Tensorstore schema, but we
             % do not use it for anything at the moment.
-            obj.TstoreSchema = py.ZarrPy.createZarr(obj.KVstoreschema, obj.DsetSize, obj.ChunkSize, obj.Tstoredtype, ...
+            obj.TstoreSchema = py.ZarrPy.createZarr(obj.KVstoreschema, py.numpy.array(obj.DsetSize),...
+                py.numpy.array(obj.ChunkSize), obj.Tstoredtype, ...
                  obj.Zarrdtype, obj.Compression, obj.FillValue);
+            %py.ZarrPy.temp(py.numpy.array([1, 1]), py.numpy.array([2, 2]))
+
 
         end
 

--- a/main.m
+++ b/main.m
@@ -86,3 +86,8 @@ dataR = zarrread(file_path);
 
 isequal(data, dataR)
 
+%%
+filepath   = "Y:\abaruah\Features\SupportZarrInGithub\Github\MATLAB-support-for-Zarr-files\test_files\singleDset5";
+data_shape = [10,10];              % shape of the Zarr array to be written
+data       = 5*ones(10,10); 
+zarrcreate(filepath, data_shape)

--- a/test_Datatype.m
+++ b/test_Datatype.m
@@ -6,7 +6,7 @@ data = single(5*ones(10, 10));
 comp.id = 'null';
 comp.level = 5;
 zarrcreate(file_path, data_shape, 'ChunkSize', chunk_shape, 'DataType', 'single',...
-    'Compression', comp);
+    'Compression', []);
 zarrwrite(file_path, data);
 dataR = zarrread(file_path);
 info = zarrinfo(file_path)


### PR DESCRIPTION
A minor bug was throwing errors while creating a Zarr dataset using `zarrcreate`. 
This was reported in https://github.com/mathworks/MATLAB-support-for-Zarr-files/issues/9

 