### PR TITLE
Make zarrinfo and zarrwriteatt independent of Python module loading

### DIFF
--- a/zarrinfo.m
+++ b/zarrinfo.m
@@ -1,4 +1,4 @@
-function info = zarrinfo(filepath)
+function infoStruct = zarrinfo(filepath)
 %ZARRINFO Retrieve info about the Zarr array
 %   INFO = ZARRINFO(FILEPATH) reads the metadata associated with a Zarr array or
 %   group located at FILEPATH, and returns the information in a structure
@@ -17,6 +17,22 @@ if ~isfolder(filepath)
     error("Invalid location.")
 end
 
-Zarrobj = Zarr(filepath);
-info = Zarrobj.readinfo;
+% If the location is a Zarr array
+if isfile(fullfile(filepath, '.zarray'))
+    infoStr = fileread(fullfile(filepath, '.zarray'));
+    infoStruct = jsondecode(infoStr);
+    infoStruct.node_type = 'array';
+% If the location is a Zarr group    
+elseif isfile(fullfile(filepath, '.zgroup'))
+    infoStr = fileread(fullfile(filepath, '.zgroup'));
+    infoStruct = jsondecode(infoStr);
+    infoStruct.node_type = 'group';
+% Supporting zarr.json for zarr v3 (low hanging fruit for future)
+elseif isfile(fullfile(filepath, 'zarr.json'))
+    infoStr = fileread(fullfile(filepath, 'zarr.json'));
+    infoStruct = jsondecode(infoStr);
+% Else, error if it is not an array or group
+else
+    error("Not a valid Zarr array or group");
+end
 end

--- a/zarrwriteatt.m
+++ b/zarrwriteatt.m
@@ -18,7 +18,30 @@ if ~isfolder(filepath)
     error("Invalid location.")
 end
 
-Zarrobj = Zarr(filepath);
-Zarrobj.writeatt(attname, attvalue);
+info = zarrinfo(filepath);
+info.(attname) = attvalue;
+
+switch (info.node_type)
+    case "array"
+        jsonfilename = fullfile(filepath, '.zarray');
+    case "group"
+        jsonfilename = fullfile(filepath, '.zgroup');
+end
+
+% 'node_type' was synthetically added by zarrinfo. So,
+% remove it from the info struct before writing it back to the
+% JSON file.
+info = rmfield(info, 'node_type');
+
+% Encode the updated structure back to JSON
+updatedJsonStr = jsonencode(info);
+
+% Write the updated JSON data back to the file
+fid = fopen(jsonfilename, 'w');
+if fid == -1
+    error(['Could not open file ''' filepath ''' for writing.']);
+end
+fwrite(fid, updatedJsonStr, 'char');
+fclose(fid);
 
 end


### PR DESCRIPTION
1. Fixed the loading of the ZarrPy module
2. zarrinfo and zarrwriteatt are using MATLAB utilities and hence do not need to load the Python libs. Moved the implementation of these two functions outside the Zarr class. This improves performance and fixes the issue #12 