### PR TITLE
Fix crash when numpy is not installed

### DIFF
--- a/PythonModule/ZarrPy.py
+++ b/PythonModule/ZarrPy.py
@@ -4,8 +4,8 @@ The module has functions for creating Zarr files, writing to Zarr files and read
 
 Copyright 2025 The MathWorks, Inc.
 """
-import tensorstore as ts
 import numpy as np
+import tensorstore as ts
 
 def createZarr(kvstore_schema, data_shape, chunk_shape, tstoreDataType, zarrDataType, compressor, fillvalue):
     """

--- a/zarrread.m
+++ b/zarrread.m
@@ -14,6 +14,6 @@ if ~isfolder(filepath)
     error("Invalid location.")
 end
 
-Zarrobj = Zarr(filepath);
-data = Zarrobj.read;
+zarrObj = Zarr(filepath);
+data = zarrObj.read;
 end

--- a/zarrwrite.m
+++ b/zarrwrite.m
@@ -16,7 +16,7 @@ if ~isfile(fullfile(filepath, '.zarray'))
 end
 
 
-Zarrobj = Zarr(filepath);
-Zarrobj.write(data)
+zarrObj = Zarr(filepath);
+zarrObj.write(data)
 
 end


### PR DESCRIPTION
Fix for https://github.com/mathworks/MATLAB-support-for-Zarr-files/issues/24