### PR TITLE
Support reading and writing of user defined attributes from and to .zattrs file

### DIFF
--- a/readZattrs.m
+++ b/readZattrs.m
@@ -1,0 +1,14 @@
+function zattrsStruct = readZattrs(filepath)
+%READZATTRS Helper function to read the JSON file .zattrs which contains
+%user defined attributes for a Zarr array or group.
+
+%   Copyright 2025 The MathWorks, Inc.
+
+userDefinedInfoStr = fileread(fullfile(filepath, '.zattrs'));
+zattrsStruct = struct();
+
+% If .zattrs file exists and is not empty
+if ~isempty(userDefinedInfoStr)
+    zattrsStruct = jsondecode(userDefinedInfoStr);
+end
+end

--- a/zarrinfo.m
+++ b/zarrinfo.m
@@ -39,8 +39,10 @@ end
 if isfile(fullfile(filepath, '.zattrs'))
     userDefinedInfoStruct = readZattrs(filepath);
     userDefinedfieldnames = fieldnames(userDefinedInfoStruct);
-    for i = 1:numel(userDefinedfieldnames)
-        infoStruct.(userDefinedfieldnames{i}) = userDefinedInfoStruct.(userDefinedfieldnames{i});
+    if (numel(userDefinedfieldnames) > 0)
+        for i = 1:numel(userDefinedfieldnames)
+            infoStruct.(userDefinedfieldnames{i}) = userDefinedInfoStruct.(userDefinedfieldnames{i});
+        end
     end
 end
 

--- a/zarrinfo.m
+++ b/zarrinfo.m
@@ -12,6 +12,10 @@ arguments
     filepath {mustBeTextScalar, mustBeNonzeroLengthText, mustBeFolder}
 end
 
+% .zarray and .zgroup are valid metadata files for Zarr v2 which contain library
+% defined attributes.
+% zarr.json is valid metadata file for Zarr v3 containing library defined
+% attributes.
 % If the location is a Zarr array
 if isfile(fullfile(filepath, '.zarray'))
     infoStr = fileread(fullfile(filepath, '.zarray'));
@@ -30,4 +34,14 @@ elseif isfile(fullfile(filepath, 'zarr.json'))
 else
     error("Not a valid Zarr array or group");
 end
+
+% User defined attributes are contained in .zattrs file in each array or group store
+if isfile(fullfile(filepath, '.zattrs'))
+    userDefinedInfoStruct = readZattrs(filepath);
+    userDefinedfieldnames = fieldnames(userDefinedInfoStruct);
+    for i = 1:numel(userDefinedfieldnames)
+        infoStruct.(userDefinedfieldnames{i}) = userDefinedInfoStruct.(userDefinedfieldnames{i});
+    end
+end
+
 end


### PR DESCRIPTION
The .zgroup and .zarray files are meant for the library only and have a restricted number of JSON NV pairs.
See here: https://zarr-specs.readthedocs.io/en/latest/v2/v2.0.html#metadata
"Other keys SHOULD NOT be present within the metadata object and SHOULD be ignored by implementations."

User defined attributes are stored in a separate .zattrs file.
https://zarr-specs.readthedocs.io/en/latest/v2/v2.0.html#attributes
"Custom attributes are encoded as a JSON object and stored under the “.zattrs” key within an array store. The “.zattrs” key does not have to be present, and if it is absent the attributes should be treated as empty."


https://zarr-specs.readthedocs.io/en/latest/v2/v2.0.html#logical-storage-paths

"For example, if an array is stored at logical path “foo/bar” then the array metadata will be stored under the key “foo/bar/.zarray”, the user-defined attributes will be stored under the key “foo/bar/.zattrs”"

This PR makes the change such that `zarrinfo` reads from both .zarray/.zgroup and .zattrs.
Similarly, `zarrwriteatt` writes custom attributes to .zattrs file 