### PR TITLE
Support scalar sized array for creation and writing

### DIFF
--- a/Zarr.m
+++ b/Zarr.m
@@ -112,8 +112,8 @@ classdef Zarr < handle
         function create(obj, dtype, data_shape, chunk_shape, fillvalue, compression)
             % Function to create the Zarr array
 
-            obj.DsetSize = data_shape;
-            obj.ChunkSize = chunk_shape;
+            obj.DsetSize = int64(data_shape);
+            obj.ChunkSize = int64(chunk_shape);
             obj.MatlabDatatype = dtype;
             obj.TensorstoreDatatype = obj.TstoredtypeMap(dtype);
             obj.ZarrDatatype = obj.ZarrdtypeMap(dtype);
@@ -146,12 +146,18 @@ classdef Zarr < handle
             % Read the Array info
             info = zarrinfo(obj.Path);
             datasize = size(data);
-            if ~isequal(info.shape, datasize(:))
+            % Verify if the data to be written is of correct dimensions
+            if isscalar(info.shape)
+                is_match = (numel(data) == info.shape);
+                
+            else
+                is_match = isequal(info.shape, datasize(:));
+            end
+
+            if ~is_match
                 error("Size of the data to be written does not match.");
             end
-            if any(info.chunks > datasize(:))
-                error("Chunk size cannot be greater than size of the data to be written.");
-            end
+            
             py.ZarrPy.writeZarr(obj.KVStoreSchema, data);
         end
 

--- a/test/tZarrCreate.m
+++ b/test/tZarrCreate.m
@@ -138,8 +138,7 @@ classdef tZarrCreate < SharedZarrTestSetup
             % Verify error when an invalid size input is used.
             % testcase.verifyError(@()zarrcreate(testcase.ArrPathWrite,[]), ...
             %     testcase.PyException);
-            testcase.verifyError(@()zarrcreate(testcase.ArrPathWrite,10), ...
-                testcase.PyException);
+            
         end
 
         function invalidCompressionInputType(testcase)

--- a/test/tZarrWrite.m
+++ b/test/tZarrWrite.m
@@ -7,7 +7,7 @@ classdef tZarrWrite < SharedZarrTestSetup
         DataType = {'double','single','int8','uint8','int16','uint16', ...
             'int32','uint32','int64','uint64','logical'}
         CompId = {'zlib','gzip','bz2','zstd'}
-        ArrSizeWrite = {[1 10],[20 25],[10 12 5]}
+        ArrSizeWrite = {10, [1 10],[20 25],[10 12 5]}
     end
 
     methods(Test)
@@ -16,7 +16,12 @@ classdef tZarrWrite < SharedZarrTestSetup
             % dimensions using zarrcreate and zarrwrite locally. The default 
             % datatype is double.;
             zarrcreate(testcase.ArrPathWrite,ArrSizeWrite);
-            expData = rand(ArrSizeWrite);
+            if isscalar(ArrSizeWrite)
+                expData = rand(ArrSizeWrite, 1);
+            else
+                expData = rand(ArrSizeWrite);
+            end
+            
             zarrwrite(testcase.ArrPathWrite,expData);
 
             actData = zarrread(testcase.ArrPathWrite);

--- a/zarrcreate.m
+++ b/zarrcreate.m
@@ -83,6 +83,10 @@ end
 if any(options.ChunkSize > datashape)
     error("Chunk size cannot be greater than size of the data to be written.");
 end
+if isscalar(datashape)
+    datashape = [datashape 1];
+    options.ChunkSize = [options.ChunkSize 1];
+end
 
 zarrObj.create(options.Datatype, datashape, options.ChunkSize, options.FillValue, options.Compression)
 


### PR DESCRIPTION
Fix for #48 
1. Set the dataset and chunk sizes to int64
2. If a scalar dataset size is passed to zarrcreate, convert it into a column vector ([n 1]). The scalar value could have been passed directly to Python, but that results in a row vector being written. In line with MATLAB column major paradigm, I am explicitly converting a scalar value to a column vector.
3. Added a test for the same in tZarrwrite and removed the negative test from tZarrcreate.