### PR TITLE
Fix test failures

### DIFF
--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - branch-bug
 
 jobs:
   test:

--- a/PythonModule/ZarrPy.py
+++ b/PythonModule/ZarrPy.py
@@ -20,7 +20,6 @@ def createZarr(kvstore_schema, data_shape, chunk_shape, tstoreDataType, zarrData
     - compressor (dictionary): The compression to be used for the Zarr array.
     - fillvalue (numeric scalar): The fill value to be used for the Zarr array.
     """
-    print(data_shape)
     schema = {
         'driver': 'zarr',
         'kvstore': kvstore_schema,

--- a/PythonModule/ZarrPy.py
+++ b/PythonModule/ZarrPy.py
@@ -20,6 +20,7 @@ def createZarr(kvstore_schema, data_shape, chunk_shape, tstoreDataType, zarrData
     - compressor (dictionary): The compression to be used for the Zarr array.
     - fillvalue (numeric scalar): The fill value to be used for the Zarr array.
     """
+    print(data_shape)
     schema = {
         'driver': 'zarr',
         'kvstore': kvstore_schema,

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![codecov](https://codecov.io/gh/mathworks/MATLAB-support-for-Zarr-files/graph/badge.svg?token=ZBLNDOLQyA)](https://codecov.io/gh/mathworks/MATLAB-support-for-Zarr-files)
 
-# MATLAB Support for Zarr files
+# MATLAB Support for Zarr files 
 
 [Zarr&reg;](https://zarr-specs.readthedocs.io/en/latest/specs.html) is a chunked, compressed, _N_-dimensional array storage format optimized for performance and scalability. It is widely used in scientific computing for handling large arrays efficiently.
 This repository provides an interface to read and write Zarr arrays and metadata from MATLAB&reg;.
@@ -31,7 +31,7 @@ Requires MATLAB release R2022b or newer
 See the link [here](https://www.mathworks.com/support/requirements/python-compatibility.html) for the Python versions compatible with different MATLAB releases.
 
 
-## Installation
+## Installation 1
 Before proceeding, please ensure that you have a supported version of Python installed on your machine.
 Please refer to the following links to configure your system to use Python with MATLAB:
 - [Configure Your System to Use Python](https://www.mathworks.com/help/matlab/matlab_external/install-supported-python-implementation.html)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Requires MATLAB release R2022b or newer
 See the link [here](https://www.mathworks.com/support/requirements/python-compatibility.html) for the Python versions compatible with different MATLAB releases.
 
 
-## Installation 1
+## Installation
 Before proceeding, please ensure that you have a supported version of Python installed on your machine.
 Please refer to the following links to configure your system to use Python with MATLAB:
 - [Configure Your System to Use Python](https://www.mathworks.com/help/matlab/matlab_external/install-supported-python-implementation.html)

--- a/test/tZarrWrite.m
+++ b/test/tZarrWrite.m
@@ -17,7 +17,7 @@ classdef tZarrWrite < SharedZarrTestSetup
             % datatype is double.;
             zarrcreate(testcase.ArrPathWrite,ArrSizeWrite);
             if isscalar(ArrSizeWrite)
-                expData = 1:10;
+                expData = (1:10)*pi;
             else
                 expData = rand(ArrSizeWrite);
             end

--- a/test/tZarrWrite.m
+++ b/test/tZarrWrite.m
@@ -17,7 +17,7 @@ classdef tZarrWrite < SharedZarrTestSetup
             % datatype is double.;
             zarrcreate(testcase.ArrPathWrite,ArrSizeWrite);
             if isscalar(ArrSizeWrite)
-                expData = rand(ArrSizeWrite, 1);
+                expData = 1:10;
             else
                 expData = rand(ArrSizeWrite);
             end

--- a/zarrcreate.m
+++ b/zarrcreate.m
@@ -84,8 +84,8 @@ if any(options.ChunkSize > datashape)
     error("Chunk size cannot be greater than size of the data to be written.");
 end
 if isscalar(datashape)
-    datashape = [datashape 1];
-    options.ChunkSize = [options.ChunkSize 1];
+    datashape = [1 datashape];
+    options.ChunkSize = [1 options.ChunkSize];
 end
 
 zarrObj.create(options.Datatype, datashape, options.ChunkSize, options.FillValue, options.Compression)


### PR DESCRIPTION
1. Fix test failures
2. For scalar values, create a row array in file instead of a column array (as submitted in https://github.com/mathworks/MATLAB-support-for-Zarr-files/pull/65)