### PR TITLE
Renaming 'is_match' to 'isCorrectShape' in Zarr.m

### DIFF
--- a/Zarr.m
+++ b/Zarr.m
@@ -170,7 +170,7 @@ classdef Zarr < handle
 
             % The compression struct should have an 'id' field.
             if ~isfield(compression, 'id')
-                error("MATLAB:Zarr:missingCompressionID","Compression id is required");
+                error("MATLAB:Zarr:missingCompressionID","Compression ID is required");
             end
             switch(compression.id)
                 case {"zlib", "gzip", "bz2", "zstd"}

--- a/Zarr.m
+++ b/Zarr.m
@@ -155,7 +155,8 @@ classdef Zarr < handle
             end
 
             if ~is_match
-                error("Size of the data to be written does not match.");
+                error("MATLAB:Zarr:sizeMismatch",...
+                    "Size of the data to be written does not match.");
             end
             
             py.ZarrPy.writeZarr(obj.KVStoreSchema, data);
@@ -169,7 +170,7 @@ classdef Zarr < handle
 
             % The compression struct should have an 'id' field.
             if ~isfield(compression, 'id')
-                error("Compression id is required");
+                error("MATLAB:Zarr:missingCompressionID","Compression id is required");
             end
             switch(compression.id)
                 case {"zlib", "gzip", "bz2", "zstd"}
@@ -189,7 +190,8 @@ classdef Zarr < handle
                         compression.shuffle = -1;
                     end
                 otherwise
-                    error('Unsupported compression id: %s', compression.id);
+                    error("MATLAB:Zarr:invalidCompressionID",...
+                        "Invalid compression id: %s", compression.id);
             end
         end
 
@@ -221,7 +223,7 @@ classdef Zarr < handle
                 bucketName = tokens{1}{1};
                 objectPath = tokens{1}{2};
             else
-                error('Invalid S3 URL or URI format');
+                error("MATLAB:Zarr:invalidS3URL","Invalid S3 URL or URI format");
             end
         end
     end

--- a/Zarr.m
+++ b/Zarr.m
@@ -148,13 +148,13 @@ classdef Zarr < handle
             datasize = size(data);
             % Verify if the data to be written is of correct dimensions
             if isscalar(info.shape)
-                is_match = (numel(data) == info.shape);
+                isCorrectShape = (numel(data) == info.shape);
                 
             else
-                is_match = isequal(info.shape, datasize(:));
+                isCorrectShape = isequal(info.shape, datasize(:));
             end
 
-            if ~is_match
+            if ~isCorrectShape
                 error("MATLAB:Zarr:sizeMismatch",...
                     "Size of the data to be written does not match.");
             end

--- a/zarrcreate.m
+++ b/zarrcreate.m
@@ -92,11 +92,13 @@ zarrObj = Zarr(filepath);
 
 % Dimensionality of the dataset and the chunk size must be the same
 if any(size(datashape) ~= size(options.ChunkSize))
-    error("Chunk size and the dataset must have the same number of dimensions.");
+    error("MATLAB:zarrcreate:chunkDimsMismatch",...
+        "Chunk size and the dataset must have the same number of dimensions.");
 end
 
 if any(options.ChunkSize > datashape)
-    error("Chunk size cannot be greater than size of the data to be written.");
+    error("MATLAB:zarrcreate:chunkSizeGreater",...
+        "Chunk size cannot be greater than size of the data to be written.");
 end
 if isscalar(datashape)
     datashape = [1 datashape];
@@ -110,6 +112,7 @@ end
 % Input validation for compresion
 function mustBeStructOrEmpty(compression)
 if ~(isstruct(compression) || isempty(compression))
-    error("Compression must be a struct or empty.");
+    error("MATLAB:zarrcreate:invalidCompression",...
+        "Compression must be a struct or empty.");
 end
 end

--- a/zarrinfo.m
+++ b/zarrinfo.m
@@ -34,7 +34,7 @@ elseif isfile(fullfile(filepath, 'zarr.json'))
     infoStruct = jsondecode(infoStr);
 % Else, error if it is not an array or group
 else
-    error("Not a valid Zarr array or group");
+    error("MATLAB:zarrinfo:invalidZarrObject","Not a valid Zarr array or group");
 end
 
 % User defined attributes are contained in .zattrs file in each array or group store

--- a/zarrwriteatt.m
+++ b/zarrwriteatt.m
@@ -16,11 +16,12 @@ arguments
 end
 
 if isfile(fullfile(filepath,'zarr.json'))
-    error("Writing attributes to Zarr v3 files is not supported.");
+    error("MATLAB:zarrwriteatt:ariteAttV3",...
+        "Writing attributes to Zarr v3 files is not supported.");
 end
 
 if (~isfile(fullfile(filepath,'.zgroup')) && ~isfile(fullfile(filepath,'.zarray')))
-    error("Not a valid Zarr group or array.");
+    error("MATLAB:zarrwriteatt:invalidZarrObject","Not a valid Zarr group or array.");
 end
 
 attrsJSONFile = fullfile(filepath, '.zattrs');
@@ -39,7 +40,8 @@ updatedJsonStr = jsonencode(userDefinedInfoStruct);
 % Write the updated JSON data back to the file
 fid = fopen(attrsJSONFile, 'w');
 if fid == -1
-    error(['Could not open file ''' filepath ''' for writing.']);
+    error("MATLAB:zarrwriteatt:fileOpenFailure",...
+        ['Could not open file ''' filepath ''' for writing.']);
 end
 fwrite(fid, updatedJsonStr, 'char');
 fclose(fid);

--- a/zarrwriteatt.m
+++ b/zarrwriteatt.m
@@ -16,7 +16,7 @@ arguments
 end
 
 if isfile(fullfile(filepath,'zarr.json'))
-    error("MATLAB:zarrwriteatt:ariteAttV3",...
+    error("MATLAB:zarrwriteatt:writeAttV3",...
         "Writing attributes to Zarr v3 files is not supported.");
 end
 


### PR DESCRIPTION
Addressed the feedback here: https://github.com/mathworks/MATLAB-support-for-Zarr-files/pull/65#discussion_r2070123835