### PR TITLE
Addressed error message feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ data     = zarrread(filepath);
 ### Create and write to a Zarr array
 ``` MATLAB
 filepath   = "myZarrfiles\singleDset";
-data_size = [10,10];              % shape of the Zarr array to be written
+data_size = [10,10];               % shape of the Zarr array to be written
 data       = 5*ones(10,10);        % Data to be written
 
-zarrcreate(filepath, data_size)  % Create the Zarr array with default attributes
+zarrcreate(filepath, data_size)    % Create the Zarr array with default attributes
 zarrwrite(filepath, data)          % Write data to the Zarr array
 ```
 
@@ -90,7 +90,7 @@ filepath = "myZarrfiles\singleZlibDset";
 % Size of the data
 data_size = [10, 20];
 % Chunk size
-chunk_shape = [5, 5];
+chunk_size = [5, 5];
 % Sample data to be written
 data = single(5*ones(10, 20));
 
@@ -99,7 +99,7 @@ compress.id = "zlib";
 compress.level = 8;
 
 % Create the Zarr array
-zarrcreate(filepath, data_size, ChunkSize=chunk_shape, DataType="single", ...
+zarrcreate(filepath, data_size, ChunkSize=chunk_size, DataType="single", ...
 	Compression=compress)
 	
 % Write to the Zarr array

--- a/README.md
+++ b/README.md
@@ -76,10 +76,10 @@ data     = zarrread(filepath);
 ### Create and write to a Zarr array
 ``` MATLAB
 filepath   = "myZarrfiles\singleDset";
-data_shape = [10,10];              % shape of the Zarr array to be written
+data_size = [10,10];              % shape of the Zarr array to be written
 data       = 5*ones(10,10);        % Data to be written
 
-zarrcreate(filepath, data_shape)  % Create the Zarr array with default attributes
+zarrcreate(filepath, data_size)  % Create the Zarr array with default attributes
 zarrwrite(filepath, data)          % Write data to the Zarr array
 ```
 
@@ -88,7 +88,7 @@ zarrwrite(filepath, data)          % Write data to the Zarr array
 filepath = "myZarrfiles\singleZlibDset";
 
 % Size of the data
-data_shape = [10, 20];
+data_size = [10, 20];
 % Chunk size
 chunk_shape = [5, 5];
 % Sample data to be written
@@ -99,7 +99,7 @@ compress.id = "zlib";
 compress.level = 8;
 
 % Create the Zarr array
-zarrcreate(filepath, data_shape, ChunkSize=chunk_shape, DataType="single", ...
+zarrcreate(filepath, data_size, ChunkSize=chunk_shape, DataType="single", ...
 	Compression=compress)
 	
 % Write to the Zarr array

--- a/Zarr.m
+++ b/Zarr.m
@@ -109,11 +109,11 @@ classdef Zarr < handle
             data = cast(ndArrayData, obj.MatlabDatatype);
         end
 
-        function create(obj, dtype, data_shape, chunk_shape, fillvalue, compression)
+        function create(obj, dtype, data_size, chunk_size, fillvalue, compression)
             % Function to create the Zarr array
 
-            obj.DsetSize = int64(data_shape);
-            obj.ChunkSize = int64(chunk_shape);
+            obj.DsetSize = int64(data_size);
+            obj.ChunkSize = int64(chunk_size);
             obj.MatlabDatatype = dtype;
             obj.TensorstoreDatatype = obj.TstoredtypeMap(dtype);
             obj.ZarrDatatype = obj.ZarrdtypeMap(dtype);
@@ -156,7 +156,7 @@ classdef Zarr < handle
 
             if ~isCorrectShape
                 error("MATLAB:Zarr:sizeMismatch",...
-                    "Size of the data to be written does not match.");
+                    "Unable to write data. Size of the data to be written must match size of the array.");
             end
             
             py.ZarrPy.writeZarr(obj.KVStoreSchema, data);
@@ -170,7 +170,8 @@ classdef Zarr < handle
 
             % The compression struct should have an 'id' field.
             if ~isfield(compression, 'id')
-                error("MATLAB:Zarr:missingCompressionID","Compression ID is required");
+                error("MATLAB:Zarr:missingCompressionID",...
+                    "Compression structure must contain an id field. Specify compression id as ""zlib"", ""gzip"", ""blosc"", ""bz2"", or ""zstd"".");
             end
             switch(compression.id)
                 case {"zlib", "gzip", "bz2", "zstd"}
@@ -191,7 +192,7 @@ classdef Zarr < handle
                     end
                 otherwise
                     error("MATLAB:Zarr:invalidCompressionID",...
-                        "Invalid compression id: %s", compression.id);
+                        "Invalid compression id. Specify compression id as ""zlib"", ""gzip"", ""blosc"", ""bz2"", or ""zstd"".");
             end
         end
 
@@ -223,7 +224,7 @@ classdef Zarr < handle
                 bucketName = tokens{1}{1};
                 objectPath = tokens{1}{2};
             else
-                error("MATLAB:Zarr:invalidS3URL","Invalid S3 URL or URI format");
+                error("MATLAB:Zarr:invalidS3URL","Invalid S3 URI.");
             end
         end
     end

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -7,10 +7,10 @@ Please refer to `README.md` for installation instructions and third-party depend
 * The use of this repository requires MATLAB release R2022b or newer.
 * Currently, only Zarr v2 is supported.
 
-## `zarrcreate(filepath,DATASHAPE,Name=Value)`
-Create a Zarr array at the path specified by `filepath` and of the dimensions specified
-by DATASHAPE. If `filepath` is a full path name, the function creates all intermediate groups that
-do not already exist. If `filepath` exists already, the contents are overwritten.
+## `zarrcreate(FILEPATH, DATASIZE, Name=Value)`
+Create a Zarr array at the path specified by `FILEPATH` and of the dimensions specified
+by `DATASIZE`. If `FILEPATH` is a full path name, the function creates all intermediate groups that
+do not already exist. If `FILEPATH` exists already, the contents are overwritten.
    
 ###	Name - Value Pairs
     Datatype                - One of "double", "single", "uint64",  
@@ -23,12 +23,14 @@ do not already exist. If `filepath` exists already, the contents are overwritten
     FillValue               - Defines the Fill value for numeric arrays.  
                               Default is [], which specifies no fill value.
 
-    Compression             - Primary compression codec used to
-                              compress the Zarr array, specified as a struct containing an "id" field. 
-                              The fields for the struct are as follows:
+    Compression             - Primary compression codec used to compress
+                              the Zarr array. By default, no compression
+                              is applied. To enable compression, specify
+                              a struct containing an "id" field. The
+                              fields for the struct are as follows:
                               "id"    - The accepted values are 'zlib', 'gzip', 
-                                        'blosc', 'bz2', 'zstd' or '[]' (default)
-                                        for no compression.
+                                        'blosc', 'bz2', or 'zstd'.
+                              The default is no compression.
                               Optional Fields:
                                 "level" - Compression level, specified as an integer. 
                                           Valid for all but "blosc" compression.
@@ -62,21 +64,21 @@ do not already exist. If `filepath` exists already, the contents are overwritten
                                               as a nonnegative integer or inf. The default value is 0.
                       
 			
-## `zarrwrite(filepath,DATA)`
-Write the MATLAB variable data (specified by DATA) to the path specified by `filepath`.
-The size of DATA must match the size of the Zarr array specified during creation.
+## `zarrwrite(FILEPATH,DATA)`
+Write the MATLAB variable data (specified by DATA) to the path specified by `FILEPATH`.
+The size of `DATA` must match the size of the Zarr array specified during creation.
 
-## `DATA = zarrread(filepath)`
-Retrieve all the data from the Zarr array located at `filepath`.
+## `DATA = zarrread(FILEPATH)`
+Retrieve all the data from the Zarr array located at `FILEPATH`.
 The datatype of DATA is the MATLAB equivalent of the Zarr datatype of the array
-located at `filepath`.
+located at `FILEPATH`.
 
-## `INFO = zarrinfo(filepath)`
-Read the metadata associated with a Zarr array or group located at `filepath` and return the information in a structure INFO, whose fields are the names of the metadata keys. 
-If `filepath` is a Zarr array (has a valid `.zarray` file), the value of `node_type` is "array"; if `filepath` is a Zarr group (has a valid `.zgroup` file), the value of the field `node_type` is "group".
-If you specify the `filepath` as a group (intermediate directory) with no `.zgroup` file, then the function will issue an error.
+## `INFO = zarrinfo(FILEPATH)`
+Read the metadata associated with a Zarr array or group located at `FILEPATH` and return the information in a structure INFO, whose fields are the names of the metadata keys. 
+If `FILEPATH` is a Zarr array (has a valid `.zarray` file), the value of `node_type` is "array"; if `FILEPATH` is a Zarr group (has a valid `.zgroup` file), the value of the field `node_type` is "group".
+If you specify the `FILEPATH` as a group (intermediate directory) with no `.zgroup` file, then the function will issue an error.
 
-## `zarrwriteatt(filepath,ATTNAME,ATTVALUE)`
-Write the attribute named ATTNAME with the value ATTVALUE to the Zarr array or group located at `filepath`. 
-The attribute is written only if a .zarray or .zgroup file exists at the location specified by `filepath`.
+## `zarrwriteatt(FILEPATH,ATTNAME,ATTVALUE)`
+Write the attribute named `ATTNAME` with the value `ATTVALUE` to the Zarr array or group located at `FILEPATH`. 
+The attribute is written only if a .zarray or .zgroup file exists at the location specified by `FILEPATH`.
 Otherwise, the function issues an error.

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -23,7 +23,7 @@ filepath = "myZarrfiles\singleZlibDset";
 % Size of the data
 data_size = [10,10];
 % Chunk size
-chunk_shape = [5,5];
+chunk_size = [5,5];
 % Sample data to be written
 data = single(5*ones(10,10));
 
@@ -32,7 +32,7 @@ compress.id = "zlib";
 compress.level = 8;
 
 % Create the Zarr array
-zarrcreate(filepath, data_size, ChunkShape=chunk_shape, DataType="single", ...
+zarrcreate(filepath, data_size, ChunkSize=chunk_size, DataType="single", ...
 	Compression=compress)
 	
 % Write to the Zarr array
@@ -44,7 +44,7 @@ zarrwrite(filepath, data)
 ``` MATLAB
 filepath = "bloscDsetFV";
 data_size = [10,10];
-chunk_shape = [5,5];
+chunk_size = [5,5];
 
 compstruct.id = "blosc";
 compstruct.cname = "snappy";
@@ -53,7 +53,7 @@ compstruct.shuffle = 0;
 compstruct.blocksize = 5;
 
 data = magic(10);
-zarrcreate(filepath, data_size, ChunkSize=chunk_shape,...
+zarrcreate(filepath, data_size, ChunkSize=chunk_size,...
     Compression=compstruct, FillValue=42)
 zarrwrite(filepath, data)
 info = zarrinfo(filepath);

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -9,10 +9,10 @@ data = zarrread(filepath)
 ### Create and write to a Zarr array
 ``` MATLAB
 filepath   = "myZarrfiles\singleDset";
-data_size = [10,10];              % shape of the Zarr array to be written
+data_size = [10,10];               % shape of the Zarr array to be written
 data       = 5*ones(10,10);        % Data to be written
 
-zarrcreate(filepath, data_size)  % Create the Zarr array with default attributes
+zarrcreate(filepath, data_size)    % Create the Zarr array with default attributes
 zarrwrite(filepath, data)          % Write "data" to the zarr array at "filepath" as a double array (default)
 ```
 

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -9,10 +9,10 @@ data = zarrread(filepath)
 ### Create and write to a Zarr array
 ``` MATLAB
 filepath   = "myZarrfiles\singleDset";
-data_shape = [10,10];              % shape of the Zarr array to be written
+data_size = [10,10];              % shape of the Zarr array to be written
 data       = 5*ones(10,10);        % Data to be written
 
-zarrcreate(filepath, data_shape)  % Create the Zarr array with default attributes
+zarrcreate(filepath, data_size)  % Create the Zarr array with default attributes
 zarrwrite(filepath, data)          % Write "data" to the zarr array at "filepath" as a double array (default)
 ```
 
@@ -21,7 +21,7 @@ zarrwrite(filepath, data)          % Write "data" to the zarr array at "filepath
 filepath = "myZarrfiles\singleZlibDset";
 
 % Size of the data
-data_shape = [10,10];
+data_size = [10,10];
 % Chunk size
 chunk_shape = [5,5];
 % Sample data to be written
@@ -32,7 +32,7 @@ compress.id = "zlib";
 compress.level = 8;
 
 % Create the Zarr array
-zarrcreate(filepath, data_shape, ChunkSize=chunk_shape, DataType="single", ...
+zarrcreate(filepath, data_size, ChunkShape=chunk_shape, DataType="single", ...
 	Compression=compress)
 	
 % Write to the Zarr array
@@ -43,7 +43,7 @@ zarrwrite(filepath, data)
 ### Create a Zarr array and write data to it using blosc compression with non-default fill value
 ``` MATLAB
 filepath = "bloscDsetFV";
-data_shape = [10,10];
+data_size = [10,10];
 chunk_shape = [5,5];
 
 compstruct.id = "blosc";
@@ -53,7 +53,7 @@ compstruct.shuffle = 0;
 compstruct.blocksize = 5;
 
 data = magic(10);
-zarrcreate(filepath, data_shape, ChunkSize=chunk_shape,...
+zarrcreate(filepath, data_size, ChunkSize=chunk_shape,...
     Compression=compstruct, FillValue=42)
 zarrwrite(filepath, data)
 info = zarrinfo(filepath);

--- a/test/tZarrAttributes.m
+++ b/test/tZarrAttributes.m
@@ -86,8 +86,7 @@ classdef tZarrAttributes < SharedZarrTestSetup
 
         function noWritePermissions(testcase)
             % Verify error if there are no write permissions to the Zarr array.
-            testcase.assumeTrue(false,'Filtered until the error syntax is fixed.');
-
+            
             % Make the folder read-only.
             fileattrib(testcase.ArrPathWrite,'-w','','s');
             testcase.addTeardown(@()fileattrib(testcase.ArrPathWrite,'+w','','s'));

--- a/zarrcreate.m
+++ b/zarrcreate.m
@@ -1,10 +1,10 @@
-function zarrcreate(filepath, datashape, options)
+function zarrcreate(filepath, datasize, options)
 %ZARRCREATE Create Zarr array.
-%   ZARRCREATE(FILEPATH, DATASHAPE, Param1, Value1, ...) Create a Zarr
-%   array at the path specified by "filepath" and of the dimensions specified
+%   ZARRCREATE(FILEPATH, DATASHAPE, Name=Value) creates a Zarr
+%   array at the path specified by FILEPATH and of the dimensions specified
 %   by DATASHAPE. 
-% If "filepath" is a full path name, the function creates all
-% intermediate groups that do not already exist. If "filepath" exists
+% If FILEPATH is a full path name, the function creates all
+% intermediate groups that do not already exist. If FILEPATH exists
 % already, the contents are overwritten.
 % 
 % Name - Value Pairs
@@ -22,13 +22,13 @@ function zarrcreate(filepath, datashape, options)
 %                               Default is [], which specifies no fill
 %                               value.
 % 
-%     Compression             - Primary compression codec used to
-%                               compress the Zarr array, specified as a
-%                               struct containing an "id" field. The fields
-%                               for the struct are as follows: "id"    -
-%                               The accepted values are "zlib", "gzip",
-%                                         "blosc", "bz2", "zstd" or []
-%                                         (default) for no compression.
+%     Compression             - Primary compression codec used to compress
+%                               the Zarr array. By default, no compression
+%                               is applied. To enable compression, specify
+%                               a struct containing an "id" field. The
+%                               fields for the struct are as follows:
+%                               "id"    - The accepted values are "zlib", "gzip",
+%                                         "blosc", "bz2", or "zstd".                               
 %                               Optional Fields:
 %                                 "level" - Compression level, specified as
 %                                           an integer.
@@ -81,8 +81,8 @@ function zarrcreate(filepath, datashape, options)
 
 arguments
     filepath {mustBeTextScalar, mustBeNonempty}
-    datashape (1,:) double {mustBeFinite, mustBeNonnegative}
-    options.ChunkSize (1,:) double {mustBeFinite, mustBeNonnegative} = datashape
+    datasize (1,:) double {mustBeFinite, mustBeNonnegative}
+    options.ChunkSize (1,:) double {mustBeFinite, mustBeNonnegative} = datasize
     options.Datatype {mustBeTextScalar, mustBeNonempty} = 'double'
     options.FillValue {mustBeNumeric} = []
     options.Compression {mustBeStructOrEmpty} = []
@@ -91,28 +91,28 @@ end
 zarrObj = Zarr(filepath);
 
 % Dimensionality of the dataset and the chunk size must be the same
-if any(size(datashape) ~= size(options.ChunkSize))
+if any(size(datasize) ~= size(options.ChunkSize))
     error("MATLAB:zarrcreate:chunkDimsMismatch",...
-        "Chunk size and the dataset must have the same number of dimensions.");
+        "Invalid chunk size. Chunk size must have the same number of dimensions as data size.");
 end
 
-if any(options.ChunkSize > datashape)
+if any(options.ChunkSize > datasize)
     error("MATLAB:zarrcreate:chunkSizeGreater",...
-        "Chunk size cannot be greater than size of the data to be written.");
+        "Invalid chunk size. Each entry of ChunkSize must be less than or equal to the corresponding entry of datasize.");
 end
-if isscalar(datashape)
-    datashape = [1 datashape];
+if isscalar(datasize)
+    datasize = [1 datasize];
     options.ChunkSize = [1 options.ChunkSize];
 end
 
-zarrObj.create(options.Datatype, datashape, options.ChunkSize, options.FillValue, options.Compression)
+zarrObj.create(options.Datatype, datasize, options.ChunkSize, options.FillValue, options.Compression)
 
 end
 
-% Input validation for compresion
+% Input validation for compression
 function mustBeStructOrEmpty(compression)
 if ~(isstruct(compression) || isempty(compression))
     error("MATLAB:zarrcreate:invalidCompression",...
-        "Compression must be a struct or empty.");
+        "Compression must be a structure or empty.");
 end
 end

--- a/zarrinfo.m
+++ b/zarrinfo.m
@@ -34,7 +34,8 @@ elseif isfile(fullfile(filepath, 'zarr.json'))
     infoStruct = jsondecode(infoStr);
 % Else, error if it is not an array or group
 else
-    error("MATLAB:zarrinfo:invalidZarrObject","Not a valid Zarr array or group");
+    error("MATLAB:zarrinfo:invalidZarrObject",...
+        "Invalid file path. File path must refer to a valid Zarr array or group.");
 end
 
 % User defined attributes are contained in .zattrs file in each array or group store

--- a/zarrread.m
+++ b/zarrread.m
@@ -1,9 +1,9 @@
 function data = zarrread(filepath)
 %ZARRREAD Read data from Zarr array
 %   DATA = ZARRREAD(FILEPATH) retrieves all the data from the Zarr array
-%   located at "filepath".
+%   located at FILEPATH.
 % The datatype of DATA is the MATLAB equivalent of the Zarr datatype of the
-% array located at "filepath".
+% array located at FILEPATH.
 
 %   Copyright 2025 The MathWorks, Inc.
 

--- a/zarrwrite.m
+++ b/zarrwrite.m
@@ -1,7 +1,7 @@
 function zarrwrite(filepath, data)
 %ZARRWRITE Write to a zarr array
 %   ZARRWRITE(FILEPATH, DATA) writes the MATLAB variable data (specified by
-%   DATA) to the path specified by "filepath".
+%   DATA) to the path specified by FILEPATH.
 % The size of DATA must match the size of the Zarr array specified during
 % creation.
 

--- a/zarrwriteatt.m
+++ b/zarrwriteatt.m
@@ -2,9 +2,9 @@ function zarrwriteatt(filepath, attname, attvalue)
 %ZARRWRITEATT Write custom Zarr attributes
 %   ZARRWRITEATT(FILEPATH,ATTNAME,ATTVALUE) Write the attribute named
 %   ATTNAME with the value ATTVALUE to the Zarr array or group located at
-%   "filepath".
+%   FILEPATH.
 % The attribute is written only if a .zarray or .zgroup file exists at the
-% location specified by "filepath". Otherwise, the function issues an
+% location specified by FILEPATH. Otherwise, the function issues an
 % error.
 
 %   Copyright 2025 The MathWorks, Inc.
@@ -21,7 +21,8 @@ if isfile(fullfile(filepath,'zarr.json'))
 end
 
 if (~isfile(fullfile(filepath,'.zgroup')) && ~isfile(fullfile(filepath,'.zarray')))
-    error("MATLAB:zarrwriteatt:invalidZarrObject","Not a valid Zarr group or array.");
+    error("MATLAB:zarrwriteatt:invalidZarrObject",...
+        "Invalid file path. File path must refer to a valid Zarr array or group.");
 end
 
 attrsJSONFile = fullfile(filepath, '.zattrs');
@@ -41,7 +42,7 @@ updatedJsonStr = jsonencode(userDefinedInfoStruct);
 fid = fopen(attrsJSONFile, 'w');
 if fid == -1
     error("MATLAB:zarrwriteatt:fileOpenFailure",...
-        ['Could not open file ''' filepath ''' for writing.']);
+        "Could not open file ""%s"" for writing.",filepath);
 end
 fwrite(fid, updatedJsonStr, 'char');
 fclose(fid);


### PR DESCRIPTION
1. Changed mention of 'data_shape' or 'datashape' to 'datasize'/ 'data_size'
2. Likewise, changed 'chunk_shape' to 'chunk_size'
3. Addressed feedback on the error IDs and error messages
4. Fixes to the documentation to make it neater.