### PR TITLE
Update zarrinfo to read from valid http links

### DIFF
--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -4,8 +4,7 @@ on:
   push:
     branches:
       - main
-      - branch-bug
-      - update-test-branch
+      - test-branch5
 
 jobs:
   test:

--- a/test/tZarrInfo.m
+++ b/test/tZarrInfo.m
@@ -34,20 +34,6 @@ classdef tZarrInfo < matlab.unittest.TestCase
             testcase.verifyEqual(actInfo,expInfo,'Failed to verify group info.');
         end
 
-        function verifyArrayInfoV3(testcase)
-            % Verify array info created with Zarr v3 format.
-            actInfo = zarrinfo(testcase.ArrPathV3);
-            expInfo = testcase.ExpInfo.zarrV3ArrInfo;
-            testcase.verifyEqual(actInfo,expInfo,'Failed to verify array info.');
-        end
-
-        function verifyGroupInfoV3(testcase)
-            % Verify group info created with Zarr v3 format.
-            actInfo = zarrinfo(testcase.GrpPathV3);
-            expInfo = testcase.ExpInfo.zarrV3GrpInfo;
-            testcase.verifyEqual(actInfo,expInfo,'Failed to verify group info.');
-        end
-
         function missingZgroupFile(testcase)
             % Verify error when using zarrinfo function on a group not
             % containing .zgroup file.
@@ -63,7 +49,7 @@ classdef tZarrInfo < matlab.unittest.TestCase
         function nonExistentArr(testcase)
             % Verify zarrinfo error when a user tries to read a non-existent
             % array.
-            errID = 'MATLAB:validators:mustBeFolder';
+            errID = 'MATLAB:zarrinfo:invalidZarrObject';
             testcase.verifyError(@()zarrinfo('nonexistentArr/'),errID);
         end
 

--- a/zarrinfo.m
+++ b/zarrinfo.m
@@ -16,8 +16,7 @@ arguments
 end
 
 % .zarray and .zgroup are valid metadata files for Zarr v2 which contain
-% library-defined attributes. zarr.json is valid metadata file for Zarr v3
-% containing library-defined attributes.
+% library-defined attributes.
 try
     infoStr = fileread(fullfile(filepath, '.zarray'));
     nodeType = 'array';


### PR DESCRIPTION
1. Removed the use of isfolder and isfile which do not work with http links.
2. Introduced the use of try-catch to check for .zarray and .zgroup attribute files.
3. Does not support Zarr v3 zarr.json anymore. It was difficult to include it with the same changes. Also, I thought it is less confusing if we enable just one function (zarrinfo) for v3. zarr v3 support for all functions can be added as a future project.