### PR TITLE
Remove mustBeFolder validation from zarrinfo and zarrwriteatt to support http URLs

### DIFF
--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -6,6 +6,7 @@ on:
       - main
       - branch-bug
       - update-test-branch
+      - test-branch6
 
 jobs:
   test:

--- a/test/tZarrAttributes.m
+++ b/test/tZarrAttributes.m
@@ -71,7 +71,7 @@ classdef tZarrAttributes < SharedZarrTestSetup
             % Verify error when using a non-existent file with zarrwriteatt 
             % function.
             testcase.verifyError(@()zarrwriteatt('testFile/nonExistentArr','myAttr','attrVal'), ...
-                'MATLAB:validators:mustBeFolder');
+                'MATLAB:zarrwriteatt:invalidZarrObject');
         end
 
         function notZarrObject(testcase)
@@ -113,7 +113,7 @@ classdef tZarrAttributes < SharedZarrTestSetup
         function invalidInput(testcase)
             % Verify error when invalid input is used for zarrwriteatt
             % function.
-            errID =  'MATLAB:validators:mustBeFolder';
+            errID =  'MATLAB:zarrwriteatt:invalidZarrObject';
 
             % Invalid file path type
             testcase.verifyError(@()zarrwriteatt('nonexistent','myAttr',10),errID);

--- a/test/tZarrInfo.m
+++ b/test/tZarrInfo.m
@@ -63,7 +63,7 @@ classdef tZarrInfo < matlab.unittest.TestCase
         function nonExistentArr(testcase)
             % Verify zarrinfo error when a user tries to read a non-existent
             % array.
-            errID = 'MATLAB:validators:mustBeFolder';
+            errID = 'MATLAB:zarrinfo:invalidZarrObject';
             testcase.verifyError(@()zarrinfo('nonexistentArr/'),errID);
         end
 

--- a/zarrinfo.m
+++ b/zarrinfo.m
@@ -12,7 +12,7 @@ function infoStruct = zarrinfo(filepath)
 %   Copyright 2025 The MathWorks, Inc.
 
 arguments
-    filepath {mustBeTextScalar, mustBeNonzeroLengthText, mustBeFolder}
+    filepath {mustBeTextScalar, mustBeNonzeroLengthText}
 end
 
 % .zarray and .zgroup are valid metadata files for Zarr v2 which contain

--- a/zarrwriteatt.m
+++ b/zarrwriteatt.m
@@ -10,7 +10,7 @@ function zarrwriteatt(filepath, attname, attvalue)
 %   Copyright 2025 The MathWorks, Inc.
 
 arguments
-    filepath {mustBeTextScalar, mustBeNonzeroLengthText, mustBeFolder}
+    filepath {mustBeTextScalar, mustBeNonzeroLengthText}
     attname {mustBeTextScalar, mustBeNonzeroLengthText}
     attvalue
 end


### PR DESCRIPTION

I close #82 becaue I thought isfile does not support http links. I was using a malformed URL.
isfile actually supports http links.
isfolder is not supported.
So, removed the use of isfolder from the validation block.
Instead, we are doing explicit checks using isfile, which works for local, http and S3.