### PR TITLE
Refactor datatype mapping

### DIFF
--- a/ZarrDatatype.m
+++ b/ZarrDatatype.m
@@ -1,0 +1,71 @@
+classdef ZarrDatatype
+    %ZARRDATATYPE Datatype of Zarr data
+    %   Represents a datatype of Zarr data and how it is mapped between 
+    %   datatypes in MATLAB, Tensorstore, and Zarr
+
+    
+    properties(Constant, Hidden)
+        % maps between three kinds of datatypes
+        MATLABTypes = ["logical", "uint8", "int8", "uint16", "int16",...
+            "uint32", "int32", "uint64", "int64", "single", "double"];
+        TensorstoreTypes = ["bool", "uint8", "int8", "uint16", "int16",...
+            "uint32", "int32", "uint64", "int64", "float32", "float64"];
+        ZarrTypes   = ["|b1", "|u1", "|i1", "<u2", "<i2",...
+            "<u4", "<i4", "<u8", "<i8", "<f4", "<f8"];
+    end
+
+    
+    properties (SetAccess = immutable, GetAccess=private, Hidden)
+        Index (1,1) int32
+    end
+
+    methods (Static)
+
+        function obj = fromMATLABType(MATLABType)
+            % Create datatype object from MATLAB datatype
+            arguments
+                MATLABType (1,1) string
+            end
+
+            validatestring(MATLABType, ZarrDatatype.MATLABTypes);
+            ind = find(MATLABType == ZarrDatatype.MATLABTypes);
+            obj = ZarrDatatype(ind);
+        end
+
+        function obj = fromTensorstoreType(tensorstoreType)
+            % Create datatype object from Tensorstore datatype
+            arguments
+                tensorstoreType (1,1) string
+            end
+
+            validatestring(tensorstoreType, ZarrDatatype.TensorstoreTypes);
+            obj = ZarrDatatype(find(tensorstoreType == ZarrDatatype.TensorstoreTypes));
+        end
+    end
+
+    methods (Hidden) %(Access=protected)
+
+        % "Private" constructor
+        function obj = ZarrDatatype(ind)
+            obj.Index = ind;
+        end
+    end
+
+    methods
+
+        function zType = ZarrType(obj)
+            % Get the corresponding Zarr datatype
+            zType = ZarrDatatype.ZarrTypes(obj.Index);
+        end
+
+        function tType = TensorstoreType(obj)
+            % Get the corresponding Tensorstore datatype
+            tType = ZarrDatatype.TensorstoreTypes(obj.Index);
+        end
+
+        function mType = MATLABType(obj)
+            % Get the corresponding MATLAB datatype
+            mType = ZarrDatatype.MATLABTypes(obj.Index);
+        end
+    end
+end

--- a/ZarrDatatype.m
+++ b/ZarrDatatype.m
@@ -2,6 +2,7 @@ classdef ZarrDatatype
     %ZARRDATATYPE Datatype of Zarr data
     %   Represents the datatype mapping between MATLAB, Tensorstore, and Zarr
 
+    % Copyright 2025 The MathWorks, Inc.
     
     properties(Constant, Hidden)
         % Same-length arrays that represent mapping between 
@@ -56,10 +57,9 @@ classdef ZarrDatatype
         function obj = fromMATLABType(MATLABType)
             % Create a datatype object based on MATLAB datatype name
             arguments
-                MATLABType (1,1) string
+                MATLABType (1,1) string {ZarrDatatype.mustBeMATLABType}
             end
 
-            validatestring(MATLABType, ZarrDatatype.MATLABTypes);
             ind = find(MATLABType == ZarrDatatype.MATLABTypes);
             obj = ZarrDatatype(ind);
         end
@@ -67,12 +67,22 @@ classdef ZarrDatatype
         function obj = fromTensorstoreType(tensorstoreType)
             % Create a datatype object based on Tensorstore datatype name
             arguments
-                tensorstoreType (1,1) string
+                tensorstoreType (1,1) string {ZarrDatatype.mustBeTensorstoreType}
             end
 
-            validatestring(tensorstoreType, ZarrDatatype.TensorstoreTypes);
             ind = find(tensorstoreType == ZarrDatatype.TensorstoreTypes);
             obj = ZarrDatatype(ind);
+        end
+
+
+        function mustBeMATLABType(type)
+            % Validator for MATLAB types
+            mustBeMember(type, ZarrDatatype.MATLABTypes);
+        end
+
+        function mustBeTensorstoreType(type)
+            % Validator for Tensorstore types
+            mustBeMember(type, ZarrDatatype.TensorstoreTypes)
         end
     end
 

--- a/ZarrDatatype.m
+++ b/ZarrDatatype.m
@@ -1,7 +1,6 @@
 classdef ZarrDatatype
     %ZARRDATATYPE Datatype of Zarr data
-    %   Represents a datatype of Zarr data and how it is mapped between 
-    %   datatypes in MATLAB, Tensorstore, and Zarr
+    %   Represents the datatype mapping between MATLAB, Tensorstore, and Zarr
 
     
     properties(Constant, Hidden)
@@ -14,7 +13,6 @@ classdef ZarrDatatype
         ZarrTypes   = ["|b1", "|u1", "|i1", "<u2", "<i2",...
             "<u4", "<i4", "<u8", "<i8", "<f4", "<f8"];
     end
-
     
     properties (SetAccess = immutable, GetAccess=private, Hidden)
         % Index into datatype arrays
@@ -22,15 +20,16 @@ classdef ZarrDatatype
     end
 
     properties (Dependent, SetAccess = immutable)
+        % Dependent properties representing the corresponding datatype in
+        % Zarr, Tensorstore, and MATLAB
         ZarrType
         TensorstoreType
         MATLABType
     end
 
-    methods (Hidden) %(Access=private)
-
-        % "Private" constructor. Should not be used directly. 
-        % Use from*Type static methods instead.
+    methods (Hidden)
+        % "Private" constructor - should not be used directly. 
+        % Use from*Type() static methods instead.
         function obj = ZarrDatatype(ind)
             obj.Index = ind;
         end
@@ -54,9 +53,8 @@ classdef ZarrDatatype
     end
 
     methods (Static)
-
         function obj = fromMATLABType(MATLABType)
-            % Create datatype object from MATLAB datatype
+            % Create a datatype object based on MATLAB datatype name
             arguments
                 MATLABType (1,1) string
             end
@@ -67,7 +65,7 @@ classdef ZarrDatatype
         end
 
         function obj = fromTensorstoreType(tensorstoreType)
-            % Create datatype object from Tensorstore datatype
+            % Create a datatype object based on Tensorstore datatype name
             arguments
                 tensorstoreType (1,1) string
             end

--- a/ZarrDatatype.m
+++ b/ZarrDatatype.m
@@ -5,7 +5,8 @@ classdef ZarrDatatype
 
     
     properties(Constant, Hidden)
-        % maps between three kinds of datatypes
+        % Same-length arrays that represent mapping between 
+        % three kinds of datatypes
         MATLABTypes = ["logical", "uint8", "int8", "uint16", "int16",...
             "uint32", "int32", "uint64", "int64", "single", "double"];
         TensorstoreTypes = ["bool", "uint8", "int8", "uint16", "int16",...
@@ -16,7 +17,40 @@ classdef ZarrDatatype
 
     
     properties (SetAccess = immutable, GetAccess=private, Hidden)
+        % Index into datatype arrays
         Index (1,1) int32
+    end
+
+    properties (Dependent, SetAccess = immutable)
+        ZarrType
+        TensorstoreType
+        MATLABType
+    end
+
+    methods (Hidden) %(Access=private)
+
+        % "Private" constructor. Should not be used directly. 
+        % Use from*Type static methods instead.
+        function obj = ZarrDatatype(ind)
+            obj.Index = ind;
+        end
+    end
+
+    methods
+        function zType = get.ZarrType(obj)
+            % Get the corresponding Zarr datatype
+            zType = ZarrDatatype.ZarrTypes(obj.Index);
+        end
+
+        function tType = get.TensorstoreType(obj)
+            % Get the corresponding Tensorstore datatype
+            tType = ZarrDatatype.TensorstoreTypes(obj.Index);
+        end
+
+        function mType = get.MATLABType(obj)
+            % Get the corresponding MATLAB datatype
+            mType = ZarrDatatype.MATLABTypes(obj.Index);
+        end
     end
 
     methods (Static)
@@ -39,33 +73,9 @@ classdef ZarrDatatype
             end
 
             validatestring(tensorstoreType, ZarrDatatype.TensorstoreTypes);
-            obj = ZarrDatatype(find(tensorstoreType == ZarrDatatype.TensorstoreTypes));
+            ind = find(tensorstoreType == ZarrDatatype.TensorstoreTypes);
+            obj = ZarrDatatype(ind);
         end
     end
 
-    methods (Hidden) %(Access=protected)
-
-        % "Private" constructor
-        function obj = ZarrDatatype(ind)
-            obj.Index = ind;
-        end
-    end
-
-    methods
-
-        function zType = ZarrType(obj)
-            % Get the corresponding Zarr datatype
-            zType = ZarrDatatype.ZarrTypes(obj.Index);
-        end
-
-        function tType = TensorstoreType(obj)
-            % Get the corresponding Tensorstore datatype
-            tType = ZarrDatatype.TensorstoreTypes(obj.Index);
-        end
-
-        function mType = MATLABType(obj)
-            % Get the corresponding MATLAB datatype
-            mType = ZarrDatatype.MATLABTypes(obj.Index);
-        end
-    end
 end

--- a/test/tZarrCreate.m
+++ b/test/tZarrCreate.m
@@ -161,6 +161,14 @@ classdef tZarrCreate < SharedZarrTestSetup
             %     testcase.PyException);
         end
 
+
+        function invalidDatatype(testcase)
+            % Verify the error when an usupported datatype is used.
+            testcase.verifyError(@()zarrcreate(testcase.ArrPathWrite,...
+                testcase.ArrSize,Datatype="bla"),...
+                'MATLAB:validators:mustBeMember');
+        end
+
         function invalidCompressionInputType(testcase)
             % Verify error when an invalid compression value is used.
             %testcase.assumeTrue(false,'Filtered until the issue is fixed.');


### PR DESCRIPTION
Move the logic of mapping between datatypes into a separate class, ZarrDatatype (instead of using dictionaries in Zarr class)

Fixes https://github.com/mathworks/MATLAB-support-for-Zarr-files/issues/14