### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+ignore-words-list = ans

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/Zarr.m
+++ b/Zarr.m
@@ -95,7 +95,7 @@ classdef Zarr < handle
             end
 
             % See if the parent path exist. Continue recursing until an
-            % exisiting parent path is found
+            % existing parent path is found
             [pathToParentFolder, ~, ~] = fileparts(path);
             existingParent = Zarr.getExistingParentFolder(pathToParentFolder);
 

--- a/test/tZarrCreate.m
+++ b/test/tZarrCreate.m
@@ -163,7 +163,7 @@ classdef tZarrCreate < SharedZarrTestSetup
 
 
         function invalidDatatype(testcase)
-            % Verify the error when an usupported datatype is used.
+            % Verify the error when an unsupported datatype is used.
             testcase.verifyError(@()zarrcreate(testcase.ArrPathWrite,...
                 testcase.ArrSize,Datatype="bla"),...
                 'MATLAB:validators:mustBeMember');


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

just a few typos (well done!) so benefit is small overall.