### PR TITLE
Unfiltering tests and cleaning up edge-cases

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+# ignore-regex = 
+ignore-words-list = ans

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/test/SharedZarrTestSetup.m
+++ b/test/SharedZarrTestSetup.m
@@ -9,6 +9,7 @@ classdef SharedZarrTestSetup < matlab.unittest.TestCase
         ChunkSize = [4 5]
 
         % Path for write tests
+        GrpPathWrite = "prt_grp_write"
         ArrPathWrite = "prt_grp_write/arr1"
     end
 

--- a/test/tZarrAttributes.m
+++ b/test/tZarrAttributes.m
@@ -7,6 +7,8 @@ classdef tZarrAttributes < SharedZarrTestSetup
         function createZarrArrayWithAttrs(testcase)
             % Create Zarr array and add some attributes.
             zarrcreate(testcase.ArrPathWrite,testcase.ArrSize);
+
+            % Write array attributes
             zarrwriteatt(testcase.ArrPathWrite,'scalarText','This is an array attribute.');
             zarrwriteatt(testcase.ArrPathWrite,'numericVector',[1,2,3]);
             zarrwriteatt(testcase.ArrPathWrite,'numericCellArray',{1,2,3});
@@ -14,6 +16,10 @@ classdef tZarrAttributes < SharedZarrTestSetup
             attrStruct.numVal = 10;
             attrStruct.strArr = ["array","attribute"];
             zarrwriteatt(testcase.ArrPathWrite,'struct',attrStruct);
+
+            % Write group attributes
+            zarrwriteatt(testcase.GrpPathWrite,'grp_description','This is a group');
+            zarrwriteatt(testcase.GrpPathWrite,'grp_level',1);
         end
     end
 
@@ -48,9 +54,10 @@ classdef tZarrAttributes < SharedZarrTestSetup
 
         function verifyAttrOverwrite(testcase)
             % Verify attribute value after overwrite.
-            
+
             expAttrStr = 'New attribute value';
             zarrwriteatt(testcase.ArrPathWrite,'scalarText',expAttrStr);
+
             expAttrDbl = 10;
             zarrwriteatt(testcase.ArrPathWrite,'numericVector',expAttrDbl);
 
@@ -66,11 +73,16 @@ classdef tZarrAttributes < SharedZarrTestSetup
         end
 
         function verifyGroupAttributeInfo(testcase)
-            % Write attribute info using zarrwriteatt function to a group.
-            testcase.assumeTrue(false,'Filtered until Issue-35 is fixed.');
+            % Verify group attribute info.
+            grpInfo = zarrinfo(testcase.GrpPathWrite);
+            
+            actAttr1 = grpInfo.grp_description;
+            expAttr1 = 'This is a group';
+            testcase.verifyEqual(actAttr1,expAttr1,'Failed to verify text attribute.');
 
-            % Unable to read attribute data from a group/array created
-            % using Python.
+            actAttr2 = grpInfo.grp_level;
+            expAttr2 = 1;
+            testcase.verifyEqual(actAttr2,expAttr2,'Failed to verify numeric attribute.');
         end
 
         function verifyZarrV3WriteError(testcase)

--- a/test/tZarrCreate.m
+++ b/test/tZarrCreate.m
@@ -243,7 +243,7 @@ classdef tZarrCreate < SharedZarrTestSetup
         end
 
         function invalidDatatype(testcase)
-            % Verify the error when an usupported datatype is used.
+            % Verify the error when an unsupported datatype is used.
             testcase.verifyError(@()zarrcreate(testcase.ArrPathWrite,...
                 testcase.ArrSize,Datatype="bla"),...
                 'MATLAB:validators:mustBeMember');


### PR DESCRIPTION
Several minor changes (mostly resulting from going over all the tests that were filtered or commented out):

1. Change in behavior for fill value. Previously the fill value was silently cast to the dataset's datatype. This could sometimes result in unexpected/xBuggy behavior. E.g.:

```MATLAB
>> zarrcreate("mygroup/myzarr", [1,2], Datatype="uint8", FillValue=-9)
>> d = zarrread("mygroup/myzarr")
 
d =
 
  1×2 uint8 row vector
 
   0   0   % not -9 because -9 cannot be represented with unsigned int
```
With this change, users will have to explicitly cast their fill value to the datasets datatype (which is more cumbersome, but avoids wrong expectations). A bit on the fence about this change, so let me know if you prefer the original approach.

The mismatch in the fill value datatype will now result in a new `MATLAB:zarrcreate:invalidFillValueType` error.
Also un-filtering and updating the corresponding `tZarrCreate/invalidFillValue` test.

2. Ensuring the dataset size cannot include zeros or be empty.  Un-filtering and updating`tZarrCreate/invalidSizeInput` test.

3. Ensuring the chunk size cannot include zeros or be empty. Un-filtering and updating `tZarrCreate/invalidChunkSize` test.
4. Making `extractS3BucketNameAndPath` into a static method. It is a helper method that does not use anything instance-specific - making it static will allow to unit-test it (see https://github.com/mathworks/MATLAB-support-for-Zarr-files/issues/88 ).
6. Un-filtering and updating `tZarrAttributes/verifyArrayAttributeInfo` and `tZarrAttributes/verifyAttrOverwrite` tests (see https://github.com/mathworks/MATLAB-support-for-Zarr-files/issues/34 - due to JSON limitations, the round-trip of attribute data is imperfect, so we should just capture the current behavior instead of keeping the tests filtered).
7. Adding `tZarrCreate/createDefaultArray` test - I don't think we were previously capturing the behavior of which default attributes zarrcreate generates.