### PR TITLE
Fix issue where python's sys.module dict fails to convert to a MATLAB dictionary

### DIFF
--- a/Zarr.m
+++ b/Zarr.m
@@ -33,9 +33,15 @@ classdef Zarr < handle
             
             % Check if the ZarrPy module is loaded already. If not, load
             % it.
-            sys = py.importlib.import_module('sys');
-            loadedModules = dictionary(sys.modules);
-            if ~loadedModules.isKey("ZarrPy")
+            try
+                sys = py.importlib.import_module('sys');
+                loadedModuleNames = string( py.list( sys.modules.keys() ) );
+                requiresZarrPyReload = any(loadedModuleNames == "ZarrPy");
+            catch
+                requiresZarrPyReload = true;
+            end
+
+            if requiresZarrPyReload
                 zarrModule = py.importlib.import_module('ZarrPy');
                 py.importlib.reload(zarrModule);
             end

--- a/Zarr.m
+++ b/Zarr.m
@@ -36,7 +36,7 @@ classdef Zarr < handle
             try
                 sys = py.importlib.import_module('sys');
                 loadedModuleNames = string( py.list( sys.modules.keys() ) );
-                requiresZarrPyReload = any(loadedModuleNames == "ZarrPy");
+                requiresZarrPyReload = ~any(loadedModuleNames == "ZarrPy");
             catch
                 requiresZarrPyReload = true;
             end


### PR DESCRIPTION
Fix issue #68 

The following line in `Zarr/pySetup` attempts to convert the `sys.modules` python dict to a MATLAB dictionary.
https://github.com/mathworks/MATLAB-support-for-Zarr-files/blob/0c96a285976905507a3ed57e5b5f1fe722f8ae3b/Zarr.m#L52

When running this, I get the following error:
```
Error using six>__get__
Python Error: AttributeError: 'NoneType' object has no attribute 'BaseHTTPServer'
```

I have not explored why, but I assume I have a python module installed which fails to convert to a MATLAB type.

Here I propose to only convert the keys of the dict to a string array and check if ZarrPy is part if that array. I also added try catch to ensure there is a fallback if the check fails.
