### PR TITLE
Update python setup logic

### DIFF
--- a/Zarr.m
+++ b/Zarr.m
@@ -47,7 +47,11 @@ classdef Zarr < handle
             % this call. For Out-of-Process Python, can just use
             % `terminate(pyenv)` instead.
 
-           py.importlib.reload(Zarr.ZarrPy);
+            % make sure the python module is on the path
+            Zarr.pySetup()
+
+            % reload
+            py.importlib.reload(Zarr.ZarrPy);
         end
 
         function isZarray = isZarrArray(path)

--- a/Zarr.m
+++ b/Zarr.m
@@ -17,10 +17,9 @@ classdef Zarr < handle
         isRemote
     end
 
-
     methods(Static)
         function pySetup
-            % Load the Python library
+            % Set up Python path
             
             % Python module setup and bootstrapping to MATLAB
             fullPath = mfilename('fullpath');
@@ -33,15 +32,26 @@ classdef Zarr < handle
             end
         end
 
-        function pyReload()
+        function zarrPy = ZarrPy()
+            % Get ZarrPy Python module
+            
+            sys = py.importlib.import_module('sys');
+            loadedModules = sys.modules;
+            zarrPy = loadedModules.get("ZarrPy", 0);
+
+            % if the zarrPy module is not loaded
+            if isnumeric(zarrPy)
+                zarrPy = py.importlib.import_module('ZarrPy');
+            end
+        end
+
+        function pyReloadInProcess()
             % Reload ZarrPy module after it has been modified (for
             % In-Process Python only). Need to do `clear classes` before
             % this call. For Out-of-Process Python, can just use
             % `terminate(pyenv)` instead.
 
-            Zarr.pySetup() % make sure ZarrPy is on the path
-            zarrModule = py.importlib.import_module('ZarrPy');
-            py.importlib.reload(zarrModule);
+            py.importlib.reload(Zarr.ZarrPy)
         end
 
         function isZarray = isZarrArray(path)
@@ -265,7 +275,7 @@ classdef Zarr < handle
                 % Extract the S3 bucket name and path
                 [bucketName, objectPath] = Zarr.extractS3BucketNameAndPath(obj.Path);
                 % Create a Python dictionary for the KV store driver
-                obj.KVStoreSchema = py.ZarrPy.createKVStore(obj.isRemote, objectPath, bucketName);
+                obj.KVStoreSchema = Zarr.ZarrPy.createKVStore(obj.isRemote, objectPath, bucketName);
                 
             else % Local file
                 % Use full path
@@ -275,7 +285,7 @@ classdef Zarr < handle
                     error("MATLAB:Zarr:invalidPath",...
                         "Unable to access path ""%s"".", path)
                 end
-                obj.KVStoreSchema = py.ZarrPy.createKVStore(obj.isRemote, obj.Path);
+                obj.KVStoreSchema = Zarr.ZarrPy.createKVStore(obj.isRemote, obj.Path);
             end
         end
 
@@ -313,7 +323,7 @@ classdef Zarr < handle
             endInds = start + stride.*count;
 
             % Read the data
-            ndArrayData = py.ZarrPy.readZarr(obj.KVStoreSchema,...
+            ndArrayData = Zarr.ZarrPy.readZarr(obj.KVStoreSchema,...
                 start, endInds, stride);
 
             % Store the datatype
@@ -366,7 +376,7 @@ classdef Zarr < handle
 
             % The Python function returns the Tensorstore schema, but we
             % do not use it for anything at the moment.
-            obj.TensorstoreSchema = py.ZarrPy.createZarr(obj.KVStoreSchema, py.numpy.array(obj.DsetSize),...
+            obj.TensorstoreSchema = Zarr.ZarrPy.createZarr(obj.KVStoreSchema, py.numpy.array(obj.DsetSize),...
                 py.numpy.array(obj.ChunkSize), obj.Datatype.TensorstoreType, ...
                  obj.Datatype.ZarrType, obj.Compression, obj.FillValue);
             %py.ZarrPy.temp(py.numpy.array([1, 1]), py.numpy.array([2, 2]))
@@ -403,7 +413,7 @@ classdef Zarr < handle
                     "Unable to write data. Size of the data to be written must match size of the array.");
             end
             
-            py.ZarrPy.writeZarr(obj.KVStoreSchema, data);
+            Zarr.ZarrPy.writeZarr(obj.KVStoreSchema, data);
         end
 
     end

--- a/Zarr.m
+++ b/Zarr.m
@@ -34,15 +34,11 @@ classdef Zarr < handle
 
         function zarrPy = ZarrPy()
             % Get ZarrPy Python module
-            
-            sys = py.importlib.import_module('sys');
-            loadedModules = sys.modules;
-            zarrPy = loadedModules.get("ZarrPy", 0);
 
-            % if the zarrPy module is not loaded
-            if isnumeric(zarrPy)
-                zarrPy = py.importlib.import_module('ZarrPy');
-            end
+            % Python will compile and cache the module after the first call
+            % to import_module, so there is no harm in making this call
+            % multiple times.
+            zarrPy = py.importlib.import_module('ZarrPy');
         end
 
         function pyReloadInProcess()
@@ -51,7 +47,7 @@ classdef Zarr < handle
             % this call. For Out-of-Process Python, can just use
             % `terminate(pyenv)` instead.
 
-            py.importlib.reload(Zarr.ZarrPy)
+           py.importlib.reload(Zarr.ZarrPy);
         end
 
         function isZarray = isZarrArray(path)

--- a/test/tZarr.m
+++ b/test/tZarr.m
@@ -29,7 +29,7 @@ classdef tZarr < SharedZarrTestSetup
         function verifyReload(testcase)
             % Verify that calling reload method does not cause any issues
 
-            Zarr.pyReloadInProcess();
+            Zarr.pyReloadInProcess()
             zarrPyModule = Zarr.ZarrPy;
             testcase.verifyTrue(isa(zarrPyModule, 'py.module'))
 

--- a/test/tZarr.m
+++ b/test/tZarr.m
@@ -1,0 +1,40 @@
+classdef tZarr < SharedZarrTestSetup
+    % Tests for Zarr class methods
+
+    % Copyright 2025 The MathWorks, Inc.
+
+    methods(Test)
+
+        function verifySupportedCloudPatterns(testcase)
+            % Verify that the bucket name and the array path can be
+            % extracted successfully if a cloud path is used as an input.
+            
+            % This list contains path pattern currently supported by Zarr
+            % in MATLAB. Any invalid path not matching any of these
+            % patterns will result in an error.
+            inpPath = {'https://mybucket.s3.us-west-2.amazonaws.com/path/to/myZarrFile', ...
+                    'https://mybucket.s3.amazonaws.com/path/to/myZarrFile', ...
+                    'https://mybucket.s3.custom-endpoint.org/path/to/myZarrFile', ...
+                    'https://s3.amazonaws.com/mybucket/path/to/myZarrFile', ...
+                    'https://s3.eu-central-1.example.edu/mybucket/path/to/myZarrFile', ...
+                    's3://mybucket/path/to/myZarrFile'};
+
+            for i = 1:length(inpPath)
+                [bucketName, objectPath] = Zarr.extractS3BucketNameAndPath(inpPath{i});
+                testcase.verifyEqual(bucketName, 'mybucket', ['Bucket name extraction failed for ' inpPath{i}]);
+                testcase.verifyEqual(objectPath, 'path/to/myZarrFile', ['Object path extraction failed for ' inpPath{i}]);
+            end
+        end
+
+        function verifyReload(testcase)
+            % Verify that calling reload method does not cause any issues
+
+            Zarr.pyReloadInProcess();
+            zarrPyModule = Zarr.ZarrPy;
+            testcase.verifyTrue(isa(zarrPyModule, 'py.module'))
+
+        end
+
+  
+    end
+end

--- a/test/tZarrCreate.m
+++ b/test/tZarrCreate.m
@@ -62,27 +62,6 @@ classdef tZarrCreate < SharedZarrTestSetup
             testcase.verifyEqual(arrInfo.node_type,'array','Unexpected Zarr array node type');
         end
 
-        function verifySupportedCloudPatterns(testcase)
-            % Verify that the bucket name and the array path can be
-            % extracted successfully if a cloud path is used as an input.
-            
-            % This list contains path pattern currently supported by Zarr
-            % in MATLAB. Any invalid path not matching any of these
-            % patterns will result in an error.
-            inpPath = {'https://mybucket.s3.us-west-2.amazonaws.com/path/to/myZarrFile', ...
-                    'https://mybucket.s3.amazonaws.com/path/to/myZarrFile', ...
-                    'https://mybucket.s3.custom-endpoint.org/path/to/myZarrFile', ...
-                    'https://s3.amazonaws.com/mybucket/path/to/myZarrFile', ...
-                    'https://s3.eu-central-1.example.edu/mybucket/path/to/myZarrFile', ...
-                    's3://mybucket/path/to/myZarrFile'};
-
-            for i = 1:length(inpPath)
-                [bucketName, objectPath] = Zarr.extractS3BucketNameAndPath(inpPath{i});
-                testcase.verifyEqual(bucketName, 'mybucket', ['Bucket name extraction failed for ' inpPath{i}]);
-                testcase.verifyEqual(objectPath, 'path/to/myZarrFile', ['Object path extraction failed for ' inpPath{i}]);
-            end
-        end
-
         function invalidFilePath(testcase)
             % Verify error when an invalid file path is used as an input to
             % zarrcreate function.

--- a/test/tZarrWrite.m
+++ b/test/tZarrWrite.m
@@ -128,7 +128,7 @@ classdef tZarrWrite < SharedZarrTestSetup
         function dataDatatypeMismatch(testcase)
             % Verify error for mismatch between datatype value and datatype 
             % of data to be written with zarrwrite.
-            errID = 'MATLAB:Python:PyExceptionWithNDArrayInfoAndMsg';
+            errID = 'MATLAB:Python:PyException';
             zarrcreate(testcase.ArrPathWrite,testcase.ArrSize,"Datatype",'int8');
             data = ones(testcase.ArrSize);
             testcase.verifyError(@()zarrwrite(testcase.ArrPathWrite,data),errID);


### PR DESCRIPTION
I've consulted with the Python interface team and reworked the logic for python setup. Changes include:

1. Moving `py.importlib.reload` into a separate method, `Zarr.pyReloadInProcess()`. Reloading of the python module is only needed during development - when the python code is changed and MATLAB is using in-process python. In that case, the developer needs to do the following in order for the updates in the python code to be picked up:

```MATLAB
clear classes
Zarr.pyReloadInProcess()
```

If they are using out-of-process python, they can just do 

```MATLAB
terminate(pyenv)
```

2. Instead of using `py.ZarrPy` to refer to the Python module, updated the code to always use the return of `py.importlib.import_module('ZarrPy')`.  Using `py.ZarrPy` **should** normally work, but there seems to be some issue with that workflow at the moment (especially with out-of-process python). So using the return of `py.importlib.import_module('ZarrPy')` is currently more robust.  We are ok to do multiple calls to `py.importlib.import_module('ZarrPy')` without any performance penalty, as it internally caches the module after the first call.


3. Added a test for the new `Zarr.pyReloadInProcess()` method. It is just a sanity check to make sure using the method does not break any functionality. Since we now have two tests for functions of Zarr class, created a separate tZarr file for those kinds of unit tests.

Fixes #68 