### PR TITLE
Updating MATLAB release field for tests

### DIFF
--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-14]
-        matlab-version: ['R2024a']
+        matlab-version: ['R2024a','latest']
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
I have configured the tests to run using 24a (oldest supported release for Zarr) and the latest available release of MATLAB.

I'll update the configuration for Python and other 3p packages separately.