### PR TITLE
Update MATLAB, Python, and 3p package versions for testing

### DIFF
--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-14]
         matlab-version: ['R2024a', 'latest']
-        python-version: ['3.10', '3.x']
 
     steps:
     - name: Checkout code
@@ -23,19 +22,26 @@ jobs:
       with:
         release: ${{matrix.matlab-version}}
 
-    - name: Set up Python
+    - name: Set up Python 3.10
+      if: matrix.matlab-version == 'R2024a'
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.10'
+
+    - name: Set up latest available Python (for latest MATLAB)
+      if: matrix.matlab-version == 'latest'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
 
     - name: Install deps (oldest supported for Python 3.10)
-      if: matrix.python-version == '3.10'
+      if: matrix.matlab-version == 'R2024a'
       run: |
         python -m pip install --upgrade pip
-        pip install "numpy==1.26.4" "tensorstore==0.1.73"
+        pip install "numpy==1.26.4" "tensorstore==0.1.71"
 
     - name: Install deps (latest for latest Python)
-      if: matrix.python-version == '3.x'
+      if: matrix.matlab-version == 'latest'
       run: |
         python -m pip install --upgrade pip
         pip install numpy tensorstore

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -22,7 +22,7 @@ jobs:
       with:
         release: ${{matrix.matlab-version}}
 
-    - name: Set up Python 3.10
+    - name: Set up Python 3.10 (oldest supported for Zarr)
       if: matrix.matlab-version == 'R2024a'
       uses: actions/setup-python@v5
       with:
@@ -34,7 +34,7 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install deps (oldest supported for Python 3.10)
+    - name: Install deps (oldest supported for Zarr)
       if: matrix.matlab-version == 'R2024a'
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -11,7 +11,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-14]
-        matlab-version: ['R2024a','latest']
+        matlab-version: ['R2024a', 'latest']
+        python-version: ['3.10', '3.x']
 
     steps:
     - name: Checkout code
@@ -25,12 +26,19 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.11.9'
+        python-version: ${{ matrix.python-version }}
 
-    - name: Install additional 3p dependencies
+    - name: Install deps (oldest supported for Python 3.10)
+      if: matrix.python-version == '3.10'
       run: |
         python -m pip install --upgrade pip
-        pip install numpy==1.26.4 tensorstore==0.1.73
+        pip install "numpy==1.26.4" "tensorstore==0.1.73"
+
+    - name: Install deps (latest for latest Python)
+      if: matrix.python-version == '3.x'
+      run: |
+        python -m pip install --upgrade pip
+        pip install numpy tensorstore
 
     - name: Run tests
       uses: matlab-actions/run-tests@v2

--- a/.github/workflows/test_setup.yml
+++ b/.github/workflows/test_setup.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-14]
-        matlab-version: ['R2024a']
+        matlab-version: ['R2024a','latest']
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
I have configured the tests to run using 24a (oldest supported MATLAB release for Zarr) and the latest available release of MATLAB. This change should be sufficient, as the latest MATLAB version will keep incrementing as new MATLAB release is made available. I already discussed this with @krisfed offline.

I have also applied a similar change to Python and related 3p packages. As the last supported Python version for MATLAB 24a is 3.11 (https://www.mathworks.com/support/requirements/python-compatibility.html), I did not want to add more combinations with different versions of Python and then apply similar combinations for the latest available MATLAB. As a result, I configured the workflow file to use,
1. Python-3.11, numpy-1.26.4, and tensorstore-0.1.71 with MATLAB R2024a, and 
2. latest available versions of Python, numpy, and tensorstore with the latest available version of MATLAB. 

In case of any changes/suggestions, please let me know.